### PR TITLE
bug:change connection string name to match new Azure database

### DIFF
--- a/cimis/station_message_queue_receiver/function.json
+++ b/cimis/station_message_queue_receiver/function.json
@@ -6,7 +6,7 @@
       "type": "serviceBusTrigger",
       "direction": "in",
       "queueName": "station",
-      "connection": "fsciwa_SERVICEBUS"
+      "connection": "fsciwabus_SERVICEBUS"
     }
   ]
 }


### PR DESCRIPTION
Connection string name was mismatched from connection string name in new Azure database. Resolved by changing name to be compliant with new database. 